### PR TITLE
Fixed '%20' appearing in payload's `ds` (data source)

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function (context, trackingId, hitType, props) {
 	var payload = {
     v: 1,
 		tid: trackingId,
-		ds: 'Sketch%20' + NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString"),
+		ds: 'Sketch ' + NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString"),
 		cid: uuid,
     t: hitType,
     an: context.plugin.name(),


### PR DESCRIPTION
Manual encoding isn't required at all, because payload keys and values are encoded just before sending.

Sketch version appears like this in GA now 😢.
![image](https://user-images.githubusercontent.com/3474842/33754658-51ce667e-dbfe-11e7-835a-d1c44519a32a.png)


