### PR TITLE
Debugged collect endpoint, it required dp to be set.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = function (context, trackingId, hitType, props) {
     t: hitType,
     an: context.plugin.name(),
     aid: context.plugin.identifier(),
-    av: context.plugin.version()
+    av: context.plugin.version(),
+    dp: '/'
   }
   if (props) {
     Object.keys(props).forEach(function (key) {


### PR DESCRIPTION
Hi Mathieu,

I tried to use this library but wouldn't get any traffic to analytics. I then manually debugged the /collect endpoint by going to /debug/collect, and discovered that it wanted me to add the "dp" property.
https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dp
This mentions "For 'pageview' hits, either &dl or both &dh and &dp have to be specified for the hit to be valid."

I now realise I choose to use hitType = "pageview" so maybe I brought this on myself, which hitType did you use to track traffic?

If this PR doesn't make sense I can also help by making a PR that adds a Readme :)

Let me know!

Michiel